### PR TITLE
Use the correct repository URL

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -10,4 +10,4 @@ the software installation and distribution tools bootstrapped by the ``ensurepip
 To use the theme either clone it directly with git, or else install it into your docs build
 environment via pip::
 
-    pip install git+https://github.com/python/python-docs-theme.git#egg=python-docs-theme
+    pip install git+https://github.com/pypa/pypa-docs-theme.git#egg=pypa-docs-theme


### PR DESCRIPTION
It was still referencing the one under the `python` org.