### PR TITLE
Remove color distinction CSS

### DIFF
--- a/pypa_theme/static/pypa.css
+++ b/pypa_theme/static/pypa.css
@@ -1,14 +1,5 @@
 @import url("pydoctheme.css");
 
-/* Add colour distinction between content and background */
-body {
-    background-color: #f7f7f7;
-}
-
-body div.footer, body div.document {
-    background-color: white;
-}
-
 /* Undo the margin override in pydoctheme */
 div.sphinxsidebarwrapper > ul > li > ul > li {
     margin-bottom: 0;


### PR DESCRIPTION
This causes artifacts with the newer css in Sphinx 1.7.

Missed it in #14.

Before:

<img width="859" alt="screen shot 2018-06-22 at 11 24 05 am" src="https://user-images.githubusercontent.com/3275593/41760001-fe9b7a18-760e-11e8-81b9-66ffd81b81f4.png">

After:

<img width="860" alt="screen shot 2018-06-22 at 11 24 34 am" src="https://user-images.githubusercontent.com/3275593/41760003-014b7d94-760f-11e8-86c3-67f746b1c34f.png">
